### PR TITLE
Enable gzip/zstd compression at the reverse proxy level

### DIFF
--- a/infra/ansible/templates/Caddyfile
+++ b/infra/ansible/templates/Caddyfile
@@ -1,3 +1,5 @@
 {{ domain }} {
   reverse_proxy server:3000
+
+  encode
 }


### PR DESCRIPTION
Reduce the amount of data transferred between the server and the client. Use the default configuration for now